### PR TITLE
Update Cookie Attributes

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,7 @@ provider:
     AGRIWEBB_MARKETPLACE_CALLBACK_URI: https://${env:API_DOMAIN_NAME}/v2/marketplace/callback
     AGRIWEBB_DOCUMENTATION_URI: https://${env:DOCS_DOMAIN_NAME}/
     AGRIWEBB_MARKETPLACE_HOMEPAGE_URI: https://${env:APP_DOMAIN_NAME}/accounts/marketplace/
+    STAGE: ${sls:stage}
 
   iam:
     role:

--- a/src/configuration-server.ts
+++ b/src/configuration-server.ts
@@ -17,6 +17,11 @@ export const REFRESH_TOKEN_TABLE_NAME = process.env.REFRESH_TOKEN_TABLE_NAME
 export const IS_DEVELOPMENT = process.env.IS_OFFLINE === 'true'
 
 /*
+  Determine if the server is running in production mode.
+*/
+export const IS_PRODUCTION = process.env.STAGE === 'prod'
+
+/*
   The base url the application is deployed at.
 */
 export const BASE_URL = (!IS_DEVELOPMENT && process.env.BASE_URL) || 'http://localhost:4000/dev/'

--- a/src/oauth2/state-manager.ts
+++ b/src/oauth2/state-manager.ts
@@ -21,7 +21,12 @@
 import base64url from 'base64url'
 import cookie, { CookieSerializeOptions } from 'cookie'
 import { createHmac, randomBytes } from 'crypto'
-import { getStateManagerSecret, REDIRECT_URI } from '../configuration-server.js'
+import {
+  getStateManagerSecret,
+  IS_DEVELOPMENT,
+  IS_PRODUCTION,
+  REDIRECT_URI,
+} from '../configuration-server.js'
 import { logger } from '../logger.js'
 
 const log = logger('state-manager')
@@ -31,8 +36,8 @@ export const setSignatureCookie = (signature: string) => {
     httpOnly: true,
     maxAge: 300,
     path: new URL(REDIRECT_URI).pathname,
-    secure: true,
-    sameSite: 'lax',
+    secure: IS_DEVELOPMENT ? false : true,
+    sameSite: IS_PRODUCTION ? 'lax' : 'none',
   }
 
   log('cookie options: %O', cookieOptions)


### PR DESCRIPTION
## Problem/Description

In our E2E tests we are encountering an error where chrome is not setting a cookie because of the following error:

> This attempt to set a cookie via a Set-Cookie header was blocked because it had the "SameSite=Lax" attribute but came from a cross-site response which was not the response to a top-level navigation.

## Solution

Update our `SameSite` policy in staging to be `None` but keep it as `Lax` in production. 